### PR TITLE
Allow device specification in pipeline init

### DIFF
--- a/gliner_spacy/pipeline.py
+++ b/gliner_spacy/pipeline.py
@@ -4,12 +4,13 @@ from spacy.language import Language
 
 
 DEFAULT_SPACY_CONFIG = {
-        "gliner_model": "urchade/gliner_base",
-        "chunk_size": 250,
-        "labels": ["person", "organization"],
-        "style": "ent",
-        "threshold": .50
-    }
+    "gliner_model": "urchade/gliner_base",
+    "chunk_size": 250,
+    "labels": ["person", "organization"],
+    "style": "ent",
+    "threshold": .50,
+    "map_location": "cpu",
+}
 
 
 @Language.factory("gliner_spacy",
@@ -23,11 +24,15 @@ class GlinerSpacy:
                  chunk_size: int,
                  labels: list,
                  style: str,
-                 threshold: float
+                 threshold: float,
+                 map_location: str
                  ):
         
         self.nlp = nlp
-        self.model = GLiNER.from_pretrained(gliner_model)
+        self.model = GLiNER.from_pretrained(
+            gliner_model,
+            map_location=map_location
+        )
         self.labels = labels
         self.chunk_size = chunk_size
         self.style = style

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-spcacy
+spacy
 gliner


### PR DESCRIPTION
This PR adds the map_location argument to the pipeline parameters and passes it to the model. This enables GPU processing if you pass an alternate torch device like cuda in.

Example use:

```
import spacy
from gliner_spacy.pipeline import GlinerSpacy

custom_spacy_config = {
    "gliner_model": "urchade/gliner_small-v1",
    "chunk_size": 384,
    "labels": ["people","company","punctuation"],
    "style": "ent",
    "map_location": "cuda",
}
nlp = spacy.blank("en")
nlp.add_pipe("gliner_spacy", config=custom_spacy_config)

text = "This is a text about Bill Gates and Microsoft." * 10000
doc = nlp(text)

for ent in doc.ents:
    print(ent.text, ent.label_)
```

The map_location defaults to CPU, so it won't use the GPU unless explicitly specified. I've tested this change locally.

Also fixed a small typo in the requirements.txt.

Thanks!