### PR TITLE
Assign score to span only if it is valid

### DIFF
--- a/gliner_spacy/pipeline.py
+++ b/gliner_spacy/pipeline.py
@@ -84,8 +84,8 @@ class GlinerSpacy:
         spans = []
         for ent in all_entities:
             span = doc.char_span(ent['start'], ent['end'], label=ent['label'])
-            span._.score = ent['score']
             if span:  # Only add span if it is valid
+                span._.score = ent['score']
                 spans.append(span)
         if self.style == "span":
             doc.spans["sc"] = spans


### PR DESCRIPTION
This PR moves the score assignment after validating the `span` variable. This should solve the problem of throwing errors when `span` is not valid:

```bash
AttributeError: 'NoneType' object has no attribute '_'
```


