### PR TITLE
Bump version for python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 This project is a wrapper for integrating [GLiNER](https://github.com/urchade/GLiNER), a Named Entity Recognition (NER) model, with the SpaCy Natural Language Processing (NLP) library. GLiNER, which stands for Generalized Language INdependent Entity Recognition, is an advanced model for recognizing entities in text. The SpaCy wrapper enables easy integration and use of GLiNER within the SpaCy environment, enhancing NER capabilities with GLiNER's advanced features.
 
-**For GliNER to work properly, you need to use a Python version 3.7-3.10**
+**For GliNER to work properly, you need to use a Python version >=3.7,<4**
 
 ## Features
 - Integrates GLiNER with SpaCy for advanced NER tasks.

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
-    python_requires='>=3.7,<3.11',
+    python_requires='>=3.7,<4',
 )


### PR DESCRIPTION
Updated `python_requires` to support Python 3.12. Current configuration means `0.0.3` is the latest release that will install with Python 3.12.

Given SemVer, I think it's reasonably safe to assume 3.13, 3.14, etc. won't introduce breaking changes. Therefore I've changed to allow any Python 3.x version greater than 3.7. 

Also updated classifiers for current supported Python versions.