### PR TITLE
Feature: Allow loading onnx models in gliner-spacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,32 @@ for ent in doc.ents:
 # Microsoft company 0.9966742992401123    
 ```
 
+## Example with loading onnx model
+```python
+import spacy
+
+custom_spacy_config = {
+    "gliner_model": "onnx-community/gliner_base",
+    "chunk_size": 250,
+    "labels": ["people", "company"],
+    "style": "ent",
+    "load_onnx_model": True,
+    "onnx_model_file": "onnx/model.onnx",
+}
+nlp = spacy.blank("en")
+nlp.add_pipe("gliner_spacy", config=custom_spacy_config)
+
+text = "This is a text about Bill Gates and Microsoft."
+doc = nlp(text)
+
+for ent in doc.ents:
+    print(ent.text, ent.label_, ent._.score)
+
+# Output
+# Bill Gates people 0.9937531352043152
+# Microsoft company 0.994135856628418
+```
+
 ## Configuration
 The default configuration of the wrapper can be modified according to your requirements. The configurable parameters are:
 - `gliner_model`: The GLiNER model to be used.
@@ -78,6 +104,8 @@ The default configuration of the wrapper can be modified according to your requi
 - `style`: The style of output for the entities (either 'ent' or 'span').
 - `threshold`: The threshold of the GliNER model (controls the degree to which a hit is considered an entity)
 - `map_location`: The device on which to run the model: `cpu` or `cuda`
+- `load_onnx_model`: Whether the `gliner_model` specificied is an ONNX model (False by default)
+- `onnx_model_file`: The path to the onnx file in the Huggingface repo. Defaults to `model.onnx`
 
 ## Contributing
 Contributions to this project are welcome. Please ensure that your code adheres to the project's coding standards and include tests for new features.

--- a/gliner_spacy/pipeline.py
+++ b/gliner_spacy/pipeline.py
@@ -21,6 +21,8 @@ DEFAULT_SPACY_CONFIG = {
     "style": "ent",
     "threshold": .50,
     "map_location": "cpu",
+    "load_onnx_model": False,
+    "onnx_model_file": "model.onnx",
 }
 
 
@@ -36,13 +38,18 @@ class GlinerSpacy:
                  labels: list,
                  style: str,
                  threshold: float,
-                 map_location: str
+                 map_location: str,
+                 load_onnx_model: bool,
+                 onnx_model_file: str,
                  ):
         
         self.nlp = nlp
         self.model = GLiNER.from_pretrained(
             gliner_model,
-            map_location=map_location
+            map_location=map_location,
+            load_onnx_model=load_onnx_model, 
+            load_tokenizer=load_onnx_model,
+            onnx_model_file=onnx_model_file
         )
         self.labels = labels
         self.chunk_size = chunk_size


### PR DESCRIPTION
Added support for loading onnx variants of the gliner model. The onnx variant (e.g. [onnx-community/gliner_base](https://huggingface.co/onnx-community/gliner_base)) runs ~5x faster compared to pytorch version of `gliner_base`.

**Usage**:
To load an onnx model, the user just has to set these new arguments in the config.

```diff
import spacy

custom_spacy_config = {
+    "gliner_model": "onnx-community/gliner_base",
     "chunk_size": 250,
     "labels": ["people", "company"],
     "style": "ent",
+    "load_onnx_model": True,
+   "onnx_model_file": "onnx/model.onnx",
}
nlp = spacy.blank("en")
nlp.add_pipe("gliner_spacy", config=custom_spacy_config)

text = "This is a text about Bill Gates and Microsoft."
doc = nlp(text)

for ent in doc.ents:
    print(ent.text, ent.label_, ent._.score)

# Output
# Bill Gates people 0.9937531352043152
# Microsoft company 0.994135856628418
 ```

**Context:**
___
Currently, `gliner-spacy` doesn't allow loading an `onnx` variant of gliner model (example: [onnx-community/gliner_base](https://huggingface.co/onnx-community/gliner_base)). It fails if you specify that repo as it will try to load the pytorch bin file.

While, the underlying `gliner` library has two arguments to support it -  `load_onnx_model` and `onnx_model_file`.

<img width="982" alt="image" src="https://github.com/user-attachments/assets/263dc5cd-6a16-4317-b6bf-74e4bede433f" />


I added support for these arguments in `gliner-spacy` in the config and have set their default values to not use onnx.

CC: @wjbmattingly 